### PR TITLE
Add invert to the "AND" and the "OR" filters

### DIFF
--- a/misery/clickhouse.py
+++ b/misery/clickhouse.py
@@ -222,15 +222,14 @@ class ClickHouseRepo(Generic[T]):
         return query
 
     def _filter_to_criterion(self, f: F) -> Criterion:
-        if f.type == FilterType.OR:
-            return Criterion.any([self._filter_to_criterion(ff) for ff in f.value])
-        elif f.type == FilterType.AND:
-            return Criterion.all([self._filter_to_criterion(ff) for ff in f.value])
-
         column = self.table[f.field]
         criterion: Any = None
 
-        if f.type == FilterType.EQ:
+        if f.type == FilterType.OR:
+            criterion = Criterion.any([self._filter_to_criterion(ff) for ff in f.value])
+        elif f.type == FilterType.AND:
+            criterion = Criterion.all([self._filter_to_criterion(ff) for ff in f.value])
+        elif f.type == FilterType.EQ:
             if f.value is None:
                 criterion = _is_null(column)
             else:

--- a/misery/core.py
+++ b/misery/core.py
@@ -432,8 +432,7 @@ class Repo(Protocol[T]):
         ...
 
     async def count_filtered(self, filter_: F) -> int:
-        """Count entities that match a given filter.
-        """
+        """Count entities that match a given filter."""
         ...
 
 

--- a/misery/postgres.py
+++ b/misery/postgres.py
@@ -254,15 +254,14 @@ class PostgresRepo(Generic[T]):
         return await self.fetch_many(query)
 
     def _filter_to_criterion(self, f: F) -> Criterion:
-        if f.type == FilterType.OR:
-            return Criterion.any([self._filter_to_criterion(ff) for ff in f.value])
-        elif f.type == FilterType.AND:
-            return Criterion.all([self._filter_to_criterion(ff) for ff in f.value])
-
         column = self.table[f.field]
         criterion: Any = None
 
-        if f.type == FilterType.EQ:
+        if f.type == FilterType.OR:
+            criterion = Criterion.any([self._filter_to_criterion(ff) for ff in f.value])
+        elif f.type == FilterType.AND:
+            criterion = Criterion.all([self._filter_to_criterion(ff) for ff in f.value])
+        elif f.type == FilterType.EQ:
             if f.value is None:
                 criterion = column.isnull()
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "misery"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Anton Evdokimov <meowmeowcode@gmail.com>"]
 description = "asyncio-friendly database toolkit"
 readme = "README.md"

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -228,6 +228,10 @@ async def test_get_many(
             {"Constipation", "Insomnia", "Helplessness"},
         ),
         ([F.and_(F.contains("name", "o"), F.contains("name", "ss"))], {"Hopelessness"}),
+        (
+            [~F.and_(F.contains("name", "o"), F.contains("name", "ss"))],
+            {"Insomnia", "Constipation", "Helplessness"},
+        ),
         ([F.contains("name", "o") & F.contains("name", "ss")], {"Hopelessness"}),
     ],
 )

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -201,6 +201,10 @@ async def test_get_many(
             {"Constipation", "Insomnia", "Helplessness"},
         ),
         ([F.and_(F.contains("name", "o"), F.contains("name", "ss"))], {"Hopelessness"}),
+        (
+            [~F.and_(F.contains("name", "o"), F.contains("name", "ss"))],
+            {"Insomnia", "Constipation", "Helplessness"},
+        ),
         ([F.contains("name", "o") & F.contains("name", "ss")], {"Hopelessness"}),
     ],
 )


### PR DESCRIPTION
Add inverting ability to AND and OR groups

Filter expression:

`~F.and_(F.contains("name", "o"), F.contains("name", "ss"))` 

will make 

`NOT ("name" LIKE '%o%' AND "name" LIKE '%ss%')`