### PR TITLE
Add case insensitive IEQ and INEQ filters

### DIFF
--- a/misery/clickhouse.py
+++ b/misery/clickhouse.py
@@ -239,6 +239,16 @@ class ClickHouseRepo(Generic[T]):
                 criterion = _is_not_null(column)
             else:
                 criterion = column != f.value
+        elif f.type == FilterType.IEQ:
+            if f.value is None:
+                criterion = _is_null(column)
+            else:
+                criterion = column.ilike(f.value)
+        elif f.type == FilterType.INEQ:
+            if f.value is None:
+                criterion = _is_not_null(column)
+            else:
+                criterion = column.not_ilike(f.value)
         elif f.type == FilterType.LT:
             criterion = column < f.value
         elif f.type == FilterType.GT:

--- a/misery/core.py
+++ b/misery/core.py
@@ -16,7 +16,9 @@ from typing import ForwardRef
 
 class FilterType(Enum):
     EQ = enum.auto()
+    IEQ = enum.auto()
     NEQ = enum.auto()
+    INEQ = enum.auto()
     LT = enum.auto()
     LTE = enum.auto()
     GT = enum.auto()
@@ -77,6 +79,15 @@ class F:
         return cls(FilterType.EQ, field, value)
 
     @classmethod
+    def ieq(cls, field: str, value: Any) -> F:
+        """Create a filter to find entities
+        with a specified field value.
+
+        Case-insensitive.
+        """
+        return cls(FilterType.IEQ, field, value)
+
+    @classmethod
     def lt(cls, field: str, value: Any) -> F:
         """Create a filter to find entities
         with a field value that is
@@ -115,6 +126,16 @@ class F:
         not equal to a given one.
         """
         return cls(FilterType.NEQ, field, value)
+
+    @classmethod
+    def ineq(cls, field: str, value: Any) -> F:
+        """Create a filter to find entities
+        with a field value that is
+        not equal to a given one.
+
+        Case-insensitive.
+        """
+        return cls(FilterType.INEQ, field, value)
 
     @classmethod
     def contains(cls, field: str, value: Any) -> F:

--- a/misery/postgres.py
+++ b/misery/postgres.py
@@ -271,6 +271,16 @@ class PostgresRepo(Generic[T]):
                 criterion = column.notnull()
             else:
                 criterion = column != f.value
+        elif f.type == FilterType.IEQ:
+            if f.value is None:
+                criterion = column.isnull()
+            else:
+                criterion = column.ilike(f.value)
+        elif f.type == FilterType.INEQ:
+            if f.value is None:
+                criterion = column.notnull()
+            else:
+                criterion = column.not_ilike(f.value)
         elif f.type == FilterType.LT:
             criterion = column < f.value
         elif f.type == FilterType.GT:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "misery"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Anton Evdokimov <meowmeowcode@gmail.com>"]
 description = "asyncio-friendly database toolkit"
 readme = "README.md"

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -164,8 +164,17 @@ async def test_get_many(
     "filters, names",
     [
         ([F.eq("name", "Insomnia")], {"Insomnia"}),
+        ([F.ieq("name", "INSOMNIA")], {"Insomnia"}),
         ([F.neq("name", "Insomnia")], {"Hopelessness", "Helplessness", "Constipation"}),
+        (
+            [F.ineq("name", "INSOMNIA")],
+            {"Hopelessness", "Helplessness", "Constipation"},
+        ),
         ([~F.eq("name", "Insomnia")], {"Hopelessness", "Helplessness", "Constipation"}),
+        (
+            [~F.ieq("name", "INSOMNIA")],
+            {"Hopelessness", "Helplessness", "Constipation"},
+        ),
         ([F.contains("name", "les")], {"Hopelessness", "Helplessness"}),
         ([F.contains("name", "LES")], set()),
         ([F.ncontains("name", "les")], {"Insomnia", "Constipation"}),

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -137,8 +137,17 @@ async def test_get_many(
     "filters, names",
     [
         ([F.eq("name", "Insomnia")], {"Insomnia"}),
+        ([F.ieq("name", "INSOMNIA")], {"Insomnia"}),
         ([F.neq("name", "Insomnia")], {"Hopelessness", "Helplessness", "Constipation"}),
+        (
+            [F.ineq("name", "INSOMNIA")],
+            {"Hopelessness", "Helplessness", "Constipation"},
+        ),
         ([~F.eq("name", "Insomnia")], {"Hopelessness", "Helplessness", "Constipation"}),
+        (
+            [~F.ieq("name", "INSOMNIA")],
+            {"Hopelessness", "Helplessness", "Constipation"},
+        ),
         ([F.contains("name", "les")], {"Hopelessness", "Helplessness"}),
         ([F.contains("name", "LES")], set()),
         ([F.ncontains("name", "les")], {"Insomnia", "Constipation"}),


### PR DESCRIPTION
Add `IEQ` and `INEQ` filter types. 

It uses `ILIKE` SQL operator to compare strings case-insensitive. 